### PR TITLE
Migrate API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Final Project for WDD330
 This is a website that will use two APIs to fetch news and weather.
 
 ### APIs
-- [NewsCatcherAPI](https://newscatcherapi.com/)
-- [OpenWeather](https://openweathermap.org/) 
+- [The Guardian OpenPlatform API](https://newscatcherapi.com/)
+- [OpenWeather API](https://openweathermap.org/) 
 
 ### Features
 Most recent news are shown but the News Search Bar can be used to search a news using keywords. Weather location will be automatically retrieved by the browser or picked using the weather search bar.

--- a/src/js/News.mjs
+++ b/src/js/News.mjs
@@ -1,12 +1,10 @@
 function newsTemplate(newsData) {
-    const dateTime = new Date(newsData.published_date).toLocaleString();
-    const author = newsData.author ? newsData.author : "Unknown Author";
+    const dateTime = new Date(newsData.webPublicationDate).toLocaleString();
     return `<div class="news-element">
         <p class="small-text">${dateTime}</p>
-        <h3>${newsData.title}</h3>
-        <p>${newsData.excerpt}</p>
-        <p class="small-text">${author}</p>
-        <a href="${newsData.link}">Read More</a>
+        <h3>${newsData.webTitle}</h3>
+        <p class="small-text">${newsData.sectionName}</p>
+        <a href="${newsData.webUrl}">Read More</a>
     </div>`;
 }
 

--- a/src/js/NewsServices.mjs
+++ b/src/js/NewsServices.mjs
@@ -13,14 +13,10 @@ export default class NewsServices {
     constructor() {
     }
     async getRecentNews() {
-        const response = await fetch(`${baseURL}latest_headlines?countries=US&lang=en`,{
-            method: 'GET',
-            headers: {
-                'x-api-key': apiKey,
-            }
-        });
+        const response = await fetch(`${baseURL}search?api-key=${apiKey}`);
         const data = await convertToJson(response);
         console.log(data);
-        return data.articles;
+        return data.response.results;
     }
+    
 }


### PR DESCRIPTION
changed API to the guardian because of newscatcher API limitations.
Finished [Migrate news API](https://trello.com/c/ndiN2cJl/14-migrate-news-api)